### PR TITLE
Issue #85 assess possibility to handle version control when reading mlxtran file

### DIFF
--- a/R/pmxClass.R
+++ b/R/pmxClass.R
@@ -40,7 +40,6 @@ pmx_sim <- function(
 }
 
 
-
 check_argument <- function(value, pmxname) {
   call <- match.call()
   if (any(missing(value) | is.null(value))) {
@@ -150,6 +149,8 @@ pmx_mlx <-
 #'
 #' @param file_name \code{character} mlxtran file path.
 #' @param call \code{logical} if TRUE the result is the parameters parsed
+#' @param version \code{integer} Non-negative integer. Non-obligatory option, if you don't use a wildcard in the file_name.
+#' Otherwise you MUST provide version and wildcard will be substituted with "version", which represents the mlxtran model version.
 #' @param ... extra arguments passed to pmx_mlx.
 #' @rdname pmx
 #'
@@ -162,7 +163,12 @@ pmx_mlx <-
 #' by mlxtran. This can be very helpful, in case you would like to customize parameters
 #' (adding settings vi pmx_settings, chnag eth edefault endpoint.)
 
-pmx_mlxtran <- function(file_name, config = "standing", call = FALSE, endpoint, ...) {
+pmx_mlxtran <- function(file_name, config = "standing", call = FALSE, endpoint, version = -1,  ...) {
+  # Substituting * with version in file_name
+  if (grepl("*", file_name, fixed = TRUE)) {
+    assert_that(version>=0, msg = "Using wildcard in file_name assume providing non-negative version")
+    file_name <- gsub("*", version, file_name, fixed = TRUE)
+  } 
   params <- parse_mlxtran(file_name)
   rr <- as.list(match.call()[-1])
   rr$file_name <- NULL
@@ -181,7 +187,9 @@ pmx_mlxtran <- function(file_name, config = "standing", call = FALSE, endpoint, 
   }
 
   params$call <- NULL
-
+  # We don't need to pass version to pmx_mlx
+  params$version <- NULL
+  
   do.call(pmx_mlx, params)
 }
 

--- a/man/pmx.Rd
+++ b/man/pmx.Rd
@@ -45,7 +45,14 @@ pmx_mlx(
   sim_blq
 )
 
-pmx_mlxtran(file_name, config = "standing", call = FALSE, endpoint, ...)
+pmx_mlxtran(
+  file_name,
+  config = "standing",
+  call = FALSE,
+  endpoint,
+  version = -1,
+  ...
+)
 }
 \arguments{
 \item{config}{Can be either :
@@ -90,6 +97,9 @@ of the endpoint code.   \code{\link{pmx_endpoint}}}
 \item{file_name}{\code{character} mlxtran file path.}
 
 \item{call}{\code{logical} if TRUE the result is the parameters parsed}
+
+\item{version}{\code{integer} Non-negative integer. Non-obligatory option, if you don't use a wildcard in the file_name.
+Otherwise you MUST provide version and wildcard will be substituted with "version", which represents the mlxtran model version.}
 
 \item{...}{extra arguments passed to pmx_mlx.}
 }

--- a/tests/testthat/test-pmxClass.R
+++ b/tests/testthat/test-pmxClass.R
@@ -141,7 +141,27 @@ test_that("can create a controller with data.frame as input", {
   expect_equal(nrow(ctr4 %>% get_data("input")), nrow(dat))
 })
 
-
 test_that("can create controller global settings",
   expect_is(pmx_settings(), "pmxSettingsClass")
 )
+
+test_that("can create a controller from mlxtran with explicit path", {
+  mlxtran_path <- file.path(system.file(package = "ggPMX"), "testdata", "1_popPK_model", "project.mlxtran")
+  ctr <- pmx_mlxtran(file_name = mlxtran_path)
+  expect_is(ctr, "pmxClass")
+})
+
+test_that("can catch absence of version, when wildcard is used in file_name", {
+  mlxtran_path <- file.path(system.file(package = "ggPMX"), "testdata", "*_popPK_model", "project.mlxtran")
+  error_msg_wrong_version <- "Using wildcard in file_name assume providing non-negative version"
+  error_msg_not_exist <- "file do not exist" 
+  expect_error(pmx_mlxtran(file_name = mlxtran_path), error_msg_wrong_version, fixed=TRUE)
+  expect_error(pmx_mlxtran(file_name = mlxtran_path, version = -5), error_msg_wrong_version, fixed=TRUE)
+  expect_error(pmx_mlxtran(file_name = mlxtran_path, version = 2), error_msg_not_exist, fixed=TRUE)
+})
+
+test_that("can create a controller from mlxtran with wildcard in path", {
+  mlxtran_path <- file.path(system.file(package = "ggPMX"), "testdata", "*_popPK_model", "project.mlxtran")
+  ctr <- pmx_mlxtran(file_name = mlxtran_path, version = 1)
+  expect_is(ctr, "pmxClass")
+})


### PR DESCRIPTION
Add logic to handle version control when reading mlxtran:
If the user doesn't use wildcard * in file_name option, minor and major versions are non-obligatory.
Otherwise, the user MUST provide major and minor non-negative versions and wildcard will be substituted by "major_version.minor_version."
