### PR TITLE
Remove horizontal line at 0 for the QQ plot of eta variables.

### DIFF
--- a/R/pmx-plots-quantile.R
+++ b/R/pmx-plots-quantile.R
@@ -85,6 +85,7 @@ pmx_plot_eta_qq <-
   function(ctr,
              ...) {
     params <- as.list(match.call(expand.dots = TRUE))[-1]
+    params <- append(params, list(is.hline=FALSE))
     wrap_pmx_plot_generic(ctr, "eta_qq", params)
   }
 


### PR DESCRIPTION
Fix first problem noted in issue 74 (hline at 0 to be removed)
Failed to replicate second problem (color of ref line not taking effect).
third problem (removing reference line) due to error in example provided.