### PR TITLE
Forcing x axis limits to include 0 when no explicit range is available.

### DIFF
--- a/R/plot-base.R
+++ b/R/plot-base.R
@@ -31,15 +31,20 @@ plot_pmx.pmx_gpar <- function(gpar, p) {
     }
 
     ## labels:title,axis,subtitle...
-    
+
     ## limits
     if (!is.null(ranges$y)) {
       p <- p %+% scale_y_continuous(limits = ranges[["y"]])
     }
     if (!is.null(ranges$x) && !discrete) {
+      ranges[["x"]]
       p <- p %+% scale_x_continuous(limits = ranges[["x"]])
     }
 
+    if(is.null(ranges[["x"]])) {
+      # Ensure that origin 0 is included on the X axis
+      p <- p %+% expand_limits(x=0)
+    }
 
     ## theming
     if (!inherits(gpar$axis.text, "element_text")) {
@@ -67,7 +72,6 @@ plot_pmx.pmx_gpar <- function(gpar, p) {
          (scale_y_log10 && !scale_x_log10))
         p <- p + geom_smooth(method="lm", se=FALSE)
         else p <- p + do.call(geom_abline, identity_line)
-
     }
 
     if (scale_x_log10) {

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -38,7 +38,7 @@ test_that("can create a plot using setting dname", {
   ctr %>% set_plot("DIS", pname = "distr1", type = "box", dname = "eta")
   p <- ctr %>% get_plot("distr1")
   pconf <- ggplot2::ggplot_build(p)
-  expect_equal(length(pconf$plot$layers), 4)
+  expect_equal(length(pconf$plot$layers), 5)
 })
 
 

--- a/tests/testthat/test-pmxClass.R
+++ b/tests/testthat/test-pmxClass.R
@@ -69,12 +69,12 @@ test_that("can set plot and filter", {
   ctr %>% set_plot("DIS", pname = "distr1", type = "box")
   p <- ctr %>% get_plot("distr1")
   pconf <- ggplot2::ggplot_build(p)
-  expect_equal(length(pconf$data), 4)
+  expect_equal(length(pconf$data), 5)
   # set plot and filter
   ctr %>% set_plot("DIS", pname = "distr2", filter = ID < 10, type = "box")
   p <- ctr %>% get_plot("distr2")
   pconf <- ggplot2::ggplot_build(p)
-  expect_equal(length(pconf$data), 4)
+  expect_equal(length(pconf$data), 5)
 })
 
 

--- a/tests/testthat/test-pmx_update.R
+++ b/tests/testthat/test-pmx_update.R
@@ -43,20 +43,20 @@ test_that("can update with filter", {
   ctr %>% get_plot("distr1")
   p <- ctr %>% get_plot("distr1")
   pconf <- ggplot2::ggplot_build(p)
-  expect_equal(length(pconf$data), 4)
+  expect_equal(length(pconf$data), 5)
 
   # Update plot with filter
   ctr %>% pmx_update("distr1", filter = ID < 10)
   p <- ctr %>% get_plot("distr1")
   pconf <- ggplot2::ggplot_build(p)
-  expect_equal(length(pconf$data), 4)
+  expect_equal(length(pconf$data), 5)
 
   # test can remove filter
   ctr %>% pmx_update("distr1", filter = NULL)
   p <- ctr %>% get_plot("distr1")
   pconf <- ggplot2::ggplot_build(p)
 
-  expect_equal(length(pconf$data), 4)
+  expect_equal(length(pconf$data), 5)
 })
 
 


### PR DESCRIPTION
To resolve #120 
Have been unable to detect missing 0 label and break with new code,
but do not have reproducible example of error..

Below is finegrid plot with 0 label on x axis:
![fine](https://user-images.githubusercontent.com/3072895/96243748-aef80b80-0f94-11eb-812d-aee8d00878f7.png)
