### PR TITLE
Fix issue: 93 If params are absent in call pmx_plot_generic don't join with defaults

### DIFF
--- a/R/pmx-all-plots.R
+++ b/R/pmx-all-plots.R
@@ -5,13 +5,18 @@ pmx_plot_generic <-
       return(NULL)
     }
     cctr <- pmx_copy(ctr, ...)
-    params <- c(
-      ctr = cctr,
-      pname = pname,
-      l_left_join(defaults_, list(...))
-    )
-    do.call("pmx_update", params)
-    p <- cctr %>% get_plot(pname)
+
+    if (length(list(...)) != 0){
+         params <- c(
+                     ctr = cctr,
+                     pname = pname,
+                     l_left_join(defaults_, list(...))
+                  )
+         do.call("pmx_update", params)
+         p <- cctr %>% get_plot(pname)
+    }
+     else
+         p <- ctr %>% get_plot(pname)
     rm(cctr)
     p
   }
@@ -35,6 +40,7 @@ wrap_pmx_plot_generic <-
     if (!exists("bloq", params) && !is.null(ctr$bloq)) {
       params$defaults_[["bloq"]] <- ctr$bloq
     }
+    
     pp <- do.call(pmx_plot_generic, params)
     if (ctr$footnote && !is.null(pp)) {
       ctr$enqueue_plot(pname)


### PR DESCRIPTION
To resolve #93 
When we call function pmx_plot_* without params under the hood we have join with default config which override previously set up parameters. 
Added condition for this case and return plot thru get_plot(pname)

Code:
```
ctr <- theophylline()
ctr %>% pmx_update("npde_pred",labels=c(title="New title!"))
ctr %>% pmx_plot_npde_pred()

```
Result:

![image](https://user-images.githubusercontent.com/10551498/96709303-2ec21380-13a3-11eb-8f85-6bae2ffe6dfe.png)
