### PR TITLE
Fix issue: 128 added aditional join with previously set parameters

### DIFF
--- a/R/pmxClass.R
+++ b/R/pmxClass.R
@@ -1148,7 +1148,7 @@ print.pmxClass <- function(x, ...) {
 #' Technically speaking we talk about chaining not piping here. However ,
 #' using \code{pmx_copy} user can work on a copy of the controller.
 #'
-#' By defaul the copy don't keep global parameters setted using pmx_settings.
+#' By default the copy does not keep global parameters set using pmx_settings.
 
 #'
 #' @examples
@@ -1165,8 +1165,9 @@ pmx_copy <- function(ctr, keep_globals = FALSE, ...) {
   if (!keep_globals) {
     nn <- rev(names(formals(pmx_settings)))[-1]
     eff_nn <- intersect(nn, names(params))
+    settings <- l_left_join(ctr$settings, params[eff_nn])
     if (length(eff_nn) > 0) {
-      cctr$settings <- do.call(pmx_settings, params[eff_nn])
+      cctr$settings <- do.call(pmx_settings, settings)
     }
   }
   cctr

--- a/man/pmx_copy.Rd
+++ b/man/pmx_copy.Rd
@@ -25,7 +25,7 @@ Some functions ( methods) can have a side effect on the controller and modify it
 Technically speaking we talk about chaining not piping here. However ,
 using \code{pmx_copy} user can work on a copy of the controller.
 
-By defaul the copy don't keep global parameters setted using pmx_settings.
+By default the copy does not keep global parameters set using pmx_settings.
 }
 \examples{
 ctr <- theophylline()


### PR DESCRIPTION
To resolve #128
Adding local settings are resetting global settings (bug seems to be present in regular plots and vpc)
Added additional join with local settings to pmx_copy function.

Code:
```
## Create controller with setting is.draft = FALSE
ctr <- theophylline(settings = pmx_settings(is.draft = FALSE))

## Plot twice the same plot, but one with an additional local setting
ctr %>% pmx_plot_dv_pred()`#plots without DRAFT watermark, as expected
ctr %>% pmx_plot_dv_pred(use.abbrev = TRUE) #plots with longer names as expected, but with DRAFT watermark
```
Resul (no draft watermark)t: 
![image](https://user-images.githubusercontent.com/10551498/96710367-a47aaf00-13a4-11eb-8f6b-b5638a0ed0e9.png)

