### PR TITLE
Fixes issue 122. Adding covariates variable subsetting for categorical ETA cov plots.

### DIFF
--- a/R/plot-eta-cov.R
+++ b/R/plot-eta-cov.R
@@ -135,7 +135,20 @@ plot_pmx.eta_cov <- function(x, dx, ...) {
     cats <- x[["cats"]]
     if (all(nzchar(x[["cats"]]))) {
       dx.cats <- dx[, c(cats, "VALUE", "EFFECT"), with = FALSE]
-      ggplot(melt(dx.cats, measure.vars = cats)) +
+      dx.cats <- melt(dx.cats, measure.vars = cats)
+
+      if (!is.null(x[["covariates"]])) {
+        dx.cats <-
+          with(
+            x[["covariates"]],
+            dx.cats[variable %in% values][
+             ,
+              variable := factor(variable, levels = values, labels = labels)
+            ]
+          )
+      }
+
+      ggplot(dx.cats) +
         geom_boxplot(aes_string(x = "value", y = "VALUE")) +
         facet_grid(stats::as.formula("EFFECT~variable"), scales = "free")
     }

--- a/R/pmx-reader.R
+++ b/R/pmx-reader.R
@@ -75,11 +75,11 @@ read_input <- function(ipath, dv, dvid, cats = "", conts = "", strats = "", occ 
 
   if (!is.null(id) && !exists(id,xx)) {
     stop(sprintf("observation data does not contain id variable: %s",id))
-  } 
+  }
   if (!is.null(time) && !exists(time,xx)) {
     stop(sprintf("observation data does not contain time variable: %s",time))
-  } 
-  
+  }
+
   if (all(c("MDV", "EVID") %in% toupper(names(xx)))) {
     setnames(xx, grep("^mdv$", names(xx), ignore.case = TRUE, value = TRUE), "MDV")
     setnames(xx, grep("^evid$", names(xx), ignore.case = TRUE, value = TRUE), "EVID")

--- a/R/pmxClass.R
+++ b/R/pmxClass.R
@@ -88,7 +88,7 @@ pmx <-
              settings = NULL, endpoint = NULL, sim = NULL, bloq = NULL,id=NULL,time=NULL) {
     directory <- check_argument(directory, "work_dir")
     ll <- list.files(directory)
-    
+
     input <- check_argument(input, "input")
     if (missing(cats)) cats <- ""
     if (missing(sim)) sim <- NULL
@@ -103,7 +103,7 @@ pmx <-
     assert_that(is_character_or_null(occ))
     if (missing(strats)) strats <- ""
     assert_that(is_character_or_null(strats))
-    
+
     if (missing(dv)) dv <- "DV"
     if (missing(dvid)) dvid <- "DVID"
 
@@ -889,7 +889,7 @@ pmx_initialize <- function(self, private, data_path, input, dv,
     self$data[["sim"]] <- merge(dx, inn, by = c("ID", "TIME"))
     self$sim <- sim
   }
-  
+
   if (config$sys == "nlmixr") {
     self$data$predictions <- input
     self$data$IND <- if (!is.null(config$finegrid)) config$finegrid else input
@@ -907,7 +907,7 @@ pmx_initialize <- function(self, private, data_path, input, dv,
     self$bloq <- bloq
     self$data$estimates <- config$parameters
   }
-  
+
   ## abbrev
   keys_file <- file.path(
     system.file(package = "ggPMX"), "init", "abbrev.yaml"


### PR DESCRIPTION
Below code example shows that covariates now take effect on categorical ETA cov plots.
```
mlx_path_1 = "ggPMX/inst/testdata/1_popPK_model/project.mlxtran"

mySet <- pmx_settings(
    is.draft=TRUE,
    use.labels = TRUE,
    cats.labels = list(
        SEX=c("1"="M","2"="F"),
                     RACE = c("1"= "As", "2"="Bl", "3" = "Vi", "Other"= "Ot"), 
                     DISE= c("1" = "Ch", "2" = "Hi"),
                     ILOW= c("1" = "Ch", "2" = "Hi")
                     )
)

ctr <- pmx_mlxtran(
  print(mlx_path_1),
  config="standing",
  settings = mySet)

# To Reproduce
cats <- pmx_cov(values = as.list(c("SEX", "RACE")))
a <- ctr %>% pmx_plot_eta_cats(covariates = cats)
conts <- pmx_cov(values = as.list(c("AGE0", "WT0")))
b <- ctr %>% pmx_plot_eta_conts(covariates = conts)
```