### PR TITLE
Removing filtering out of 0-DV values as this may lead to inaccurate …

### DIFF
--- a/R/pmx-reader.R
+++ b/R/pmx-reader.R
@@ -137,7 +137,8 @@ read_input <- function(ipath, dv, dvid, cats = "", conts = "", strats = "", occ 
     } else {
       xx[, DV := get(dv)]
     }
-    xx <- xx[DV != 0]
+    # Omitting 0-value observations for compatibility with log transformations
+    #xx <- xx[DV != 0]
   } else {
     dv.names <- paste(setdiff(names(xx), c("ID", "id", "time", "TIME")), collapse = " or ")
     dv.names <- sprintf("'%s'", dv.names)


### PR DESCRIPTION
Closes #146

If the original intention behind the filtering out of 0 values was to avoid problems when plotting with log-transformed x-axes, this is not really necessary as setting `scale_x_log10=TRUE` leads to warning messages about the introduction of infinite values on the continous x-axis, and plotting the results without those values. The same holds true for the y axis, and for the case where both x and y axes are log-transformed.