### PR TITLE
Changing way params are read to include variables from global.

### DIFF
--- a/R/pmx-plots-eta-cov.R
+++ b/R/pmx-plots-eta-cov.R
@@ -86,6 +86,6 @@ pmx_plot_eta_cats <-
 pmx_plot_eta_conts <-
   function(ctr,
              ...) {
-    params <- as.list(match.call(expand.dots = TRUE))[-1]
+    params <- list(...)
     wrap_pmx_plot_generic(ctr, "eta_conts", params)
   }


### PR DESCRIPTION
fixes #135

This use of `match.call` may cause similar problems elsewhere in the codebase.

Will create a general issue.