### PR TITLE
Add tinytex for R-CMD-check.yaml

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: r-lib/actions/setup-tinytex@master
+
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
Tinytex was not installed into tested OSs resulting into a missing 'pdflatex' programm available from the tested OSs.