### PR TITLE
Adding test of pmx vpc plot with strat.facet argument

### DIFF
--- a/tests/testthat/test-pmx-plot-vpc.R
+++ b/tests/testthat/test-pmx-plot-vpc.R
@@ -1,0 +1,7 @@
+context("Test VPC plot")
+
+test_that("pmx_plot_vpc: params: ctr, strat.facet; result: ggplot", {
+  ctr <- theophylline()
+  p <- pmx_plot_vpc(ctr, strat.facet = ~STUD)
+  expect_s3_class(p, 'ggplot')
+})


### PR DESCRIPTION
Adding test to prevent regression of error using strat.facet argument in vpc plot

fixes #102 