### PR TITLE
Gh217 footnote argument pmx vpc plot

### DIFF
--- a/R/plot-vpc.R
+++ b/R/plot-vpc.R
@@ -515,11 +515,11 @@ vpc.plot <- function(x) {
       }
       pp <- pp + do.call("facet_wrap", c(strat.facet, facets))
     }
-    if (is.footnote){
-      pp <- pp +labs(caption=x$footnote)
-    }
-    
-    
+
+    if (is.footnote){pp <- pp + labs(caption=x$footnote)}
+
+    pp
+
   })
 }
 

--- a/tests/testthat/test-pmx-plot-vpc.R
+++ b/tests/testthat/test-pmx-plot-vpc.R
@@ -1,0 +1,7 @@
+context("Test VPC plot")
+
+test_that("pmx_plot_vpc: params: ctr, is.footnote; result: ggplot", {
+  ctr <- theophylline()
+  p <- pmx_plot_vpc(ctr, is.footnote=FALSE)
+  expect_s3_class(p, 'ggplot')
+})


### PR DESCRIPTION
Fixes #217 

- **Cause**: a certain path through the `vpc.plot` function did not return a plot object
- **Solution**: adding explicit return of plot object at end of function

**Additional**:
- have added __testthat__ test to avoid regression of error