### PR TITLE
Gh216 no rugs on pmx vpc plot

### DIFF
--- a/R/plot-vpc.R
+++ b/R/plot-vpc.R
@@ -447,24 +447,20 @@ vpc.plot <- function(x) {
       )
       do.call(geom_point, params)
     }
-    
-    ## Rug layer was removed because of two reasons:
-      # - Didn't work properly with within_strats = TRUE, Rugs did not represent the bins
-      # - Rugs are not vital for the interpretation of VPCs plots
-    
-    #rug_layer <- if (!is.null(rug)) {
-      #params <- append(
-       # list(
-      #    mapping = aes(x = x, y = y),
-       #   sides = "t",
-      #    data = db$rug_dt
-       # ),
-      #  rug
-      #)
-      #do.call(geom_rug, params)
-    #}
-    
-    
+
+    rug_layer <- if ((!is.null(rug))){
+      params <- append(
+        list(
+          mapping = aes(x = x, y = y),
+          sides = "t",
+          data = db$rug_dt
+        ),
+        rug
+      )
+      do.call(geom_rug, params)
+    }
+
+
     ci_med_layer <- function() {if (!is.null(ci)) {
       nn <- grep("CL", names(db$ci_dt), value = TRUE)[c(1, 3)]
       params <- append(
@@ -489,15 +485,10 @@ vpc.plot <- function(x) {
       params$fill <- NULL
       do.call(geom_ribbon, params)
     }}
-    
-    
-    ## + rug_layer was removed because of two reasons:
-    # - Didn't work properly with within_strats = TRUE, Rugs did not represent the bins
-    # - Rugs are not vital for the interpretation of VPCs plots
-    
+
     pp <- ggplot(data = db$pi_dt, aes_string(x = if (!is.null(bin)) "bin" else idv)) +
-      obs_layer + pi_med_layer() + pi_ext_layer()  #+ rug_layer
-    
+      obs_layer + pi_med_layer() + pi_ext_layer() + rug_layer
+
     pp <- if (type=="scatter") pp +  pi_shaded_layer() 
     else pp + ci_med_layer() + ci_ext_layer() 
     if(!is.null(x$obs_legend)){

--- a/R/pmx-plots-vpc.R
+++ b/R/pmx-plots-vpc.R
@@ -23,7 +23,9 @@
 #' @param obs \code{pmx_vpc_obs} object observation layer \link{pmx_vpc_obs}
 #' @param pi \code{pmx_vpc_pi} object percentile layer  \link{pmx_vpc_pi}
 #' @param ci \code{pmx_vpc_ci} object confidence interval layer  \link{pmx_vpc_ci}
-#' @param rug  \code{pmx_vpc_rug} object rug layer  \link{pmx_vpc_rug}
+#' @param rug  \code{pmx_vpc_rug} object rug layer  \link{pmx_vpc_rug}.
+#' Note: consider not using a rug layer when bin[["within_strat"]]=TRUE,
+#' since the rugs plotted will not reflect the bins.
 #' @param bin \code{pmx_vpc_bin} object  \link{pmx_vpc_bin} specify within pmx_plot_vpc() e.g.: bin = pmx_vpc_bin(style = "kmeans", n = 10)
 #' @param is.legend \code{logical} if TRUE add legend
 #' @param is.footnote \code{logical} if TRUE add footnote

--- a/R/pmx-plots-vpc.R
+++ b/R/pmx-plots-vpc.R
@@ -78,7 +78,20 @@ pmx_plot_vpc <-
              axis.title, axis.text, ranges, is.smooth, smooth, is.band,
              band, is.draft, draft, is.identity_line, identity_line,
              scale_x_log10, scale_y_log10, color.scales, is.footnote,...) {
+
+    if(!missing(bin) && !is.null(bin) && bin[["within_strat"]] &&
+      !missing (rug) && !is.null(rug)) {
+      warning(
+        paste0(
+          "Consider not using a rugs layer ",
+          "when bin argument has within_strats=TRUE, since the rugs will ",
+          "not reflect the bins.",
+          "This can be achieved by setting rugs=NULL, or omitting it, ",
+          "in the call to pmx_plot_vpc.")
+      )
+    }
+
     params <- as.list(match.call(expand.dots = TRUE))[-1]
     params$is.smooth <- FALSE
     wrap_pmx_plot_generic(ctr, "pmx_vpc", params)
-  }
+}

--- a/man/pmx_plot_vpc.Rd
+++ b/man/pmx_plot_vpc.Rd
@@ -54,7 +54,9 @@ pmx_plot_vpc(
 
 \item{ci}{\code{pmx_vpc_ci} object confidence interval layer  \link{pmx_vpc_ci}}
 
-\item{rug}{\code{pmx_vpc_rug} object rug layer  \link{pmx_vpc_rug}}
+\item{rug}{\code{pmx_vpc_rug} object rug layer  \link{pmx_vpc_rug}.
+Note: consider not using a rug layer when bin[["within_strat"]]=TRUE,
+since the rugs plotted will not reflect the bins.}
 
 \item{bin}{\code{pmx_vpc_bin} object  \link{pmx_vpc_bin} specify within pmx_plot_vpc() e.g.: bin = pmx_vpc_bin(style = "kmeans", n = 10)}
 


### PR DESCRIPTION
Fixes #216 

1. reinstates rug layer of `pmx_plot_vpc`
2. adds warning if `rug` used together with `bin[["within_strat"]] =TRUE`