### PR TITLE
Improvements to eta cov

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,8 @@ Imports:
     rlang,
     tibble,
     checkmate,
-    scales
+    scales,
+    plyr
 License: GPL-2
 Suggests:
     testthat,

--- a/R/plot-eta-cov.R
+++ b/R/plot-eta-cov.R
@@ -48,7 +48,7 @@ is_pmxcov <- function(x)
 #' @param jitter list set jitter parameter
 #' @param scale string parameter for y axis ("fix", "free", "free_y", "sym")
 #' @param is.shrink \code{logical} if TRUE add shrinkage to the plot
-#' @param shrink\code{list} shrinkage graphical parameter
+#' @param shrink \code{list} shrinkage graphical parameter
 #' @param ... others graphics arguments passed to \code{\link{pmx_gpar}} internal object.
 
 #'

--- a/R/plot-eta-cov.R
+++ b/R/plot-eta-cov.R
@@ -42,6 +42,13 @@ is_pmxcov <- function(x)
 #' @param facets \code{list} facetting graphical parameter
 #' @param covariates \code{pmxCOVObject} \code{\link{pmx_cov}}
 #' @param is.strat.color \code{logical} if `TRUE` use a different color for the spline stratification.
+#' @param is.hline \code{logical} if TRUE add horizontal line to lower matrix plots
+#' @param hline \code{list} geom_hline graphical parameters
+#' @param is.jitter \code{logical} if TRUE add jitter operator for points
+#' @param jitter list set jitter parameter
+#' @param scale string parameter for y axis ("fix", "free", "free_y", "sym")
+#' @param is.shrink \code{logical} if TRUE add shrinkage to the plot
+#' @param shrink\code{list} shrinkage graphical parameter
 #' @param ... others graphics arguments passed to \code{\link{pmx_gpar}} internal object.
 
 #'
@@ -63,15 +70,21 @@ eta_cov <- function(
                     correl = NULL,
                     facets = NULL,
                     point = NULL,
+                    is.hline = FALSE,
+                    hline = NULL,
                     covariates = NULL,
                     is.strat.color = FALSE,
+                    is.jitter = FALSE,
+                    jitter = NULL,
+                    scale = "free",
+                    is.shrink = TRUE,
+                    shrink = NULL,
                     ...) {
   type <- match.arg(type)
   assert_that(is_string_or_null(dname))
   assert_that(is_pmxcov(covariates))
 
   if (is.null(dname)) dname <- "eta"
-
 
   if (missing(labels)) {
     labels <- list(
@@ -91,8 +104,15 @@ eta_cov <- function(
     correl = correl,
     facets = facets,
     point = point,
+    is.hline = is.hline,
+    hline = hline,
     covariates = covariates,
     is.strat.color = is.strat.color,
+    is.jitter = is.jitter,
+    jitter = jitter,
+    scale = scale,
+    is.shrink = is.shrink,
+    shrink = shrink,
     gp = pmx_gpar(
       labels = labels,
       discrete = TRUE,
@@ -101,21 +121,55 @@ eta_cov <- function(
   ), class = c("eta_cov", "pmx_gpar"))
 }
 
+check_shrink <- function(shrink) {
+  if (is.null(shrink$x))
+    shrink$x = -Inf
+  if (is.null(shrink$y))
+    shrink$y = Inf
+  if (is.null(shrink$hjust))
+    shrink$hjust = -0.2
+  if (is.null(shrink$vjust))
+    shrink$vjust = 1.2
+  if (is.null(shrink$size))
+    shrink$size = 4
+  shrink
+}
 
+get_shrink_val <- function(shrink.dx, shrink) {
+  df_shr <- shrink.dx
+  df_shr$SHRINK <-
+    sapply(shrink.dx$SHRINK, function (x)
+      sprintf("%s%%", round(x * 100)))
+  shr_eqn <- function(x) {
+    eq <- substitute(italic(shrink) == a, list(a = x))
+    as.character(as.expression(eq))
+  }
+  shrink <- check_shrink(shrink)
+  df_shr[, shr_exp := shr_eqn(SHRINK), "EFFECT"]
+  shrink_val <- list(
+    data = df_shr,
+    x = shrink$x,
+    y = shrink$y,
+    hjust = shrink$hjust,
+    vjust = shrink$vjust,
+    size = shrink$size,
+    mapping = aes(label = shr_exp),
+    parse = TRUE
+  )
+  shrink_val
+}
 
-
-
-
-
-
-
-
-
-
-
-
-
-
+check_jitter <- function(jitter){
+  if (is.null(jitter$size))
+    jitter$size = 2
+  if (is.null(jitter$colour))
+    jitter$colour = "black"
+  if (is.null(jitter$shape))
+    jitter$shape = 20
+  if (is.null(jitter$alpha))
+    jitter$alpha = 1
+  jitter
+}
 
 #' This plots an ETA covariance matrix which can be used to define the co-relation between the parameters and
 #' its shrinkage
@@ -137,8 +191,9 @@ plot_pmx.eta_cov <- function(x, dx, ...) {
     x$gp$is.smooth <- FALSE
     cats <- x[["cats"]]
     if (all(nzchar(x[["cats"]]))) {
-      dx.cats <- dx[, c(cats, "VALUE", "EFFECT"), with = FALSE]
-      dx.cats <- melt(dx.cats, measure.vars = cats)
+      dx.cats <- unique(dx[, c(cats, "VALUE", "EFFECT"), with = FALSE])
+      df <- dx.cats
+      dx.cats <- melt(dx.cats, id = c("VALUE", "EFFECT"))
       if (!is.null(x$covariates)) {
         dx.cats <-
           with(
@@ -148,7 +203,10 @@ plot_pmx.eta_cov <- function(x, dx, ...) {
               variable := factor(variable, levels = values, labels = labels)
             ]
           )
+       if (all(unlist(x$covariates$values) %in% names(df)))
+           df <- df %>% dplyr::select(unlist(x$covariates$values), "VALUE", "EFFECT")
       }
+
       if (x$is.strat.color) {
         if(length(cats) > 1) {
           dx.cats <- dx.cats[, var_val = paste0(variable, value)]
@@ -160,9 +218,28 @@ plot_pmx.eta_cov <- function(x, dx, ...) {
         boxplot_layers <- geom_boxplot(aes_string(x = "value", y = "VALUE"))
       }
 
-      ggplot(dx.cats, measure.vars = cats) +
+      x$jitter <- check_jitter(x$jitter)
+      if (x$scale == "sym") scale_y <- get_scale_y(df)
+
+      p <- ggplot(dx.cats, measure.vars = cats) +
         boxplot_layers +
-        facet_grid(stats::as.formula("EFFECT~variable"), scales = "free")
+        geom_boxplot(aes_string(x = "value", y = "VALUE")) +
+        {if(x$is.hline)geom_hline(aes(yintercept=x$hline))} +
+        facet_grid_scale(stats::as.formula("EFFECT~variable"),
+                         scales = x$scale, scale_y = scale_y) +
+        {if(x$is.jitter)geom_point(aes(group=VALUE),
+                                   color = x$jitter$colour,
+                                   size = x$jitter$size,
+                                   shape=x$jitter$shape,
+                                   alpha=x$jitter$alpha
+                                  )
+        }
+
+      if (x$is.shrink) {
+        shrink_val <- get_shrink_val(x$shrink.dx, x$shrink)
+        p <- p + do.call("geom_text", shrink_val)
+      }
+      p
     }
   } else {
     value <- variable <- corr <- corr_exp <- NULL
@@ -177,7 +254,7 @@ plot_pmx.eta_cov <- function(x, dx, ...) {
             dx.conts[variable %in% values][
               ,
               variable := factor(variable, levels = values, labels = labels)
-            ]
+              ]
           )
       }
       x$facets$facets <- stats::as.formula("EFFECT~variable")
@@ -190,7 +267,7 @@ plot_pmx.eta_cov <- function(x, dx, ...) {
           dx.conts[
             , list(corr = round(cor(get("value"), get("VALUE"), use = "na.or.complete"), 3)),
             "EFFECT,variable"
-          ]
+            ]
 
         corr_eqn <- function(x) {
           eq <- substitute(italic(corr) == a, list(a = x))

--- a/man/eta_cov.Rd
+++ b/man/eta_cov.Rd
@@ -13,8 +13,15 @@ eta_cov(
   correl = NULL,
   facets = NULL,
   point = NULL,
+  is.hline = FALSE,
+  hline = NULL,
   covariates = NULL,
   is.strat.color = FALSE,
+  is.jitter = FALSE,
+  jitter = NULL,
+  scale = "free",
+  is.shrink = TRUE,
+  shrink = NULL,
   ...
 )
 }
@@ -33,11 +40,25 @@ eta_cov(
 
 \item{point}{\code{list} geom point graphical parameter}
 
+\item{is.hline}{\code{logical} if TRUE add horizontal line to lower matrix plots}
+
+\item{hline}{\code{list} geom_hline graphical parameters}
+
 \item{covariates}{\code{pmxCOVObject} \code{\link{pmx_cov}}}
 
 \item{is.strat.color}{\code{logical} if `TRUE` use a different color for the spline stratification.}
 
+\item{is.jitter}{\code{logical} if TRUE add jitter operator for points}
+
+\item{jitter}{list set jitter parameter}
+
+\item{scale}{string parameter for y axis ("fix", "free", "free_y", "sym")}
+
+\item{is.shrink}{\code{logical} if TRUE add shrinkage to the plot}
+
 \item{...}{others graphics arguments passed to \code{\link{pmx_gpar}} internal object.}
+
+\item{shrink\code{list}}{shrinkage graphical parameter}
 }
 \value{
 \code{eta_cov} object

--- a/man/eta_cov.Rd
+++ b/man/eta_cov.Rd
@@ -56,9 +56,9 @@ eta_cov(
 
 \item{is.shrink}{\code{logical} if TRUE add shrinkage to the plot}
 
-\item{...}{others graphics arguments passed to \code{\link{pmx_gpar}} internal object.}
+\item{shrink}{\code{list} shrinkage graphical parameter}
 
-\item{shrink\code{list}}{shrinkage graphical parameter}
+\item{...}{others graphics arguments passed to \code{\link{pmx_gpar}} internal object.}
 }
 \value{
 \code{eta_cov} object

--- a/man/facet_wrap_paginate.Rd
+++ b/man/facet_wrap_paginate.Rd
@@ -47,8 +47,8 @@ one with \code{vars(cyl, am)}. Each output
 column gets displayed as one separate line in the strip
 label. This function should inherit from the "labeller" S3 class
 for compatibility with \code{\link[ggplot2:labeller]{labeller()}}. You can use different labeling
-functions for different kind of labels, for example use \code{\link[ggplot2:label_parsed]{label_parsed()}} for
-formatting facet labels. \code{\link[ggplot2:label_value]{label_value()}} is used by default,
+functions for different kind of labels, for example use \code{\link[ggplot2:labellers]{label_parsed()}} for
+formatting facet labels. \code{\link[ggplot2:labellers]{label_value()}} is used by default,
 check it for more details and pointers to other options.}
 
 \item{as.table}{If \code{TRUE}, the default, the facets are laid out like

--- a/tests/testthat/test-pmx-plot-eta-cov.R
+++ b/tests/testthat/test-pmx-plot-eta-cov.R
@@ -8,14 +8,6 @@ test_that(
     expect_equal(p$plot_env$x$is.strat.color, TRUE)
   }
 )
-#------------------- pmx_plot_eta_cats end --------------------------------------------
-
-context("Test pmx Eta Covariates plots")
-
-ctr <- theophylline(settings = pmx_settings(effects = list(
-  levels = c("ka", "V", "Cl"),
-  labels = c("Concentration", "Volume", "Clearance")
-)))
 
 #------------------- pmx_plot_eta_cats start -------------------------------
 test_that(
@@ -60,7 +52,203 @@ test_that(
 
    }
 )
+
+
+test_that("pmx_plot_eta_cats: params: ctr is controller result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr), "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is controller, strat.color, strat.facet result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(
+              pmx_plot_eta_cats(ctr = ctr, strat.color = "STUD", strat.facet =  ~ SEX),
+              "gg"
+            ))
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is controller, is.hline=TRUE, hline result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(
+              pmx_plot_eta_cats(ctr = ctr, is.hline=TRUE, hline = 0.25),
+              "gg"
+            ))
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is controller, is.hline=FALSE result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr,
+                                                   is.hline = FALSE),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is controller, is.jitter = FALSE result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr,
+                                                   is.jitter = FALSE),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is controller, is.jitter = TRUE, jitter  result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr,
+                                                   is.jitter = TRUE,
+                                                   jitter = list(shape = 24,
+                                                                 colour = 'red',
+                                                                 size =2)),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is controller, is.jitter = TRUE, jitter is NULL  result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr,
+                                                   is.jitter = TRUE,
+                                                   jitter = NULL),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is controller, is.shrink = FALSE result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr,
+                                                   is.shrink = FALSE),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is controller, is.shrink = TRUE, shrink  result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr,
+                                                   is.shrink = TRUE,
+                                                   shrink = list(fun = 'var',
+                                                                 size = 3,
+                                                                 x = 0.5)),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats:
+          params: ctr is controller, is.jitter = TRUE, jitter is Int result: error",
+          {
+ctr <- theophylline()
+            expect_error(pmx_plot_eta_cats(ctr = ctr,
+                                           is.jitter = TRUE,
+                                           jitter = 0))
+          })
+
+test_that("pmx_plot_eta_cats:
+          params: ctr is controller, is.shrink = TRUE, shrink is Int result: error",
+          {
+ctr <- theophylline()
+            expect_error(pmx_plot_eta_cats(ctr = ctr,
+                                           is.shrink = TRUE,
+                                           shrink = 0))
+          })
+
+test_that("pmx_plot_eta_cats:
+           params: ctr is controller, is.shrink = TRUE, shrink is NULL  result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr,
+                                                   is.shrink = TRUE,
+                                                   shrink = NULL),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is controller, covariates result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(
+              ctr = ctr,
+              covariates = pmx_cov(
+                values = list("RACE", "DISE"),
+                labels = list("Race", "Disease")
+              )
+            ),
+            "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is controller, labels result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_conts(
+              ctr = ctr,
+              labels = list(title = "EBE vs discrete covariates")
+            ),
+            "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: params: no result: error",
+          {
+            expect_error(pmx_plot_eta_cats())
+          })
+
+test_that("pmx_plot_eta_cats: params: ctr is not controller result: error",
+          {
+            ctr <- theophylline() %>% get_data("eta")
+            expect_error(pmx_plot_eta_cats(ctr = ctr))
+          })
+
+test_that("pmx_plot_eta_cats: 
+           params: ctr is controller, scale is sym  result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr, 
+                                                   scale = "sym"),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: 
+           params: ctr is controller, scale is sym, covariates  result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr, 
+                                                   scale = "sym",
+                                                   covariates=pmx_cov(values=list("SEX"),
+                                                                      labels=list("SEX"))),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: 
+           params: ctr is controller, scale is free  result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr, 
+                                                   scale = "free"),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: 
+           params: ctr is controller, scale is fix  result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_cats(ctr = ctr, 
+                                                   scale = "fix"),
+                                 "gg"))
+          })
+
+test_that("pmx_plot_eta_cats: 
+          params: ctr is controller, scale is other result: error",
+          {
+            ctr <- theophylline() 
+            expect_error(pmx_plot_eta_cats(ctr = ctr, 
+                                           scale = "other"))
+          })
+
 #------------------- pmx_plot_eta_cats end ---------------------------------
+
+context("Test pmx Eta Covariates plots")
+
+ctr <- theophylline(settings = pmx_settings(effects = list(
+                                              levels = c("ka", "V", "Cl"),
+                                              labels = c("Concentration", "Volume", "Clearance")
+                                            )))
 
 #------------------- pmx_plot_eta_conts start ------------------------------
 test_that(
@@ -77,4 +265,41 @@ test_that(
     "gg"))
   }
 )
+
+test_that("pmx_plot_eta_conts: params: ctr is controller result: gg", {
+  ctr <- theophylline()
+  expect_true(inherits(pmx_plot_eta_conts(ctr = ctr), "gg"))
+})
+
+test_that("pmx_plot_eta_conts: params: ctr is controller, strat.color, strat.facet result: gg", {
+  ctr <- theophylline()
+  expect_true(inherits(
+    pmx_plot_eta_conts(ctr = ctr, strat.color = "STUD", strat.facet =  ~ SEX),
+    "gg"
+  ))
+})
+
+test_that("pmx_plot_eta_conts: params: ctr is controller, covariates result: gg",
+          {
+            ctr <- theophylline()
+            expect_true(inherits(pmx_plot_eta_conts(
+              ctr = ctr,
+              covariates = pmx_cov(
+                values = list("WT0", "AGE0"),
+                labels = list("Weight", "Age")
+              )
+            ),
+            "gg"))
+          })
+
+test_that("pmx_plot_eta_conts: params: no result: error",
+          {
+            expect_error(pmx_plot_eta_conts())
+          })
+
+test_that("pmx_plot_eta_conts: params: ctr is not controller result: error",
+          {
+            ctr <- theophylline() %>% get_data("eta")
+            expect_error(pmx_plot_eta_conts(ctr = ctr))
+          })
 #------------------- pmx_plot_eta_conts end --------------------------------


### PR DESCRIPTION
Fixes #71 
- now uses `data.table` instead of `dplyr` (as opposed to  #158)