### PR TITLE
Adding logic not to modify title label if it is custom

### DIFF
--- a/R/pmx-add-plot.R
+++ b/R/pmx-add-plot.R
@@ -81,17 +81,15 @@ before_add_check <- function(self, private, x, pname) {
     gp[["labels"]][["legend"]] <- x[["strat.color"]]
     x[["gp"]] <- gp
   }
-  if (!is.null(x[["strat.facet"]])) {
-    tit <- x$gp[["labels"]][["title"]]
-    tit <- gsub(" by .*", "", tit)
-    if ((isTRUE(x$gp[["custom_title"]])) && (x$gp[["custom_title"]] == FALSE)) {
-      x$gp[["labels"]][["title"]] <- sprintf("%s by %s",
-        tit, formula_to_text(x[["strat.facet"]]))
-    }
-  }
-  else {
-    if ((isTRUE(x$gp[["custom_title"]])) && (x$gp[["custom_title"]] == FALSE)) {
-      x$gp[["labels"]][["title"]] <- gsub(" by.*", "", x$gp[["labels"]][["title"]])
+
+  if (isFALSE(x[["gp"]][["custom_title"]])) {
+    x[["gp"]][["labels"]][["title"]] <- gsub(" by .*", "", x[["gp"]][["labels"]][["title"]])
+    if (!is.null(x[["strat.facet"]])) {
+      x[["gp"]][["labels"]][["title"]] <- sprintf(
+          "%s by %s",
+          x[["gp"]][["labels"]][["title"]],
+          formula_to_text(x[["strat.facet"]])
+        )
     }
   }
   invisible(x)

--- a/R/pmx-add-plot.R
+++ b/R/pmx-add-plot.R
@@ -84,12 +84,15 @@ before_add_check <- function(self, private, x, pname) {
   if (!is.null(x[["strat.facet"]])) {
     tit <- x$gp[["labels"]][["title"]]
     tit <- gsub(" by .*", "", tit)
-    x$gp[["labels"]][["title"]] <-
-      sprintf(
-        "%s by %s", tit, formula_to_text(x[["strat.facet"]])
-      )
-  } else {
-    x$gp[["labels"]][["title"]] <- gsub(" by.*", "", x$gp[["labels"]][["title"]])
+    if ((isTRUE(x$gp[["custom_title"]])) && (x$gp[["custom_title"]] == FALSE)) {
+      x$gp[["labels"]][["title"]] <- sprintf("%s by %s",
+        tit, formula_to_text(x[["strat.facet"]]))
+    }
+  }
+  else {
+    if ((isTRUE(x$gp[["custom_title"]])) && (x$gp[["custom_title"]] == FALSE)) {
+      x$gp[["labels"]][["title"]] <- gsub(" by.*", "", x$gp[["labels"]][["title"]])
+    }
   }
   invisible(x)
 }

--- a/R/pmx-all-plots.R
+++ b/R/pmx-all-plots.R
@@ -67,6 +67,7 @@ wrap_pmx_plot_generic <-
     params$pname <- pname
     params <- lang_to_expr(params)
     params$defaults_ <- ctr$config$plots[[toupper(pname)]]
+    params[["custom_title"]] <- is.character(params[["labels"]][["title"]])
     if (!exists("bloq", params) && !is.null(ctr$bloq)) {
       params$defaults_[["bloq"]] <- ctr$bloq
     }

--- a/tests/testthat/test-pmx_update.R
+++ b/tests/testthat/test-pmx_update.R
@@ -90,7 +90,7 @@ test_that("plot title with start.facet", {
   p2 <- ctr %>% pmx_plot_iwres_ipred(strat.color = "AGE0", strat.facet = SEX ~ STUD)
   # Custom label still takes priority
   p3 <- pmx_plot_iwres_ipred(
-    crt,
+    ctr,
     strat.color = "AGE0",
     strat.facet = SEX ~ STUD,
     labels=list(title="CUSTOM_A vs CUSTOM_B by CUSTOM_OVERRIDE")

--- a/tests/testthat/test-pmx_update.R
+++ b/tests/testthat/test-pmx_update.R
@@ -88,7 +88,15 @@ test_that("plot title with start.facet", {
   # Change x- and y-labels
   p1 <- ctr %>% pmx_plot_iwres_ipred(strat.color = "AGE0", strat.facet = ~STUD)
   p2 <- ctr %>% pmx_plot_iwres_ipred(strat.color = "AGE0", strat.facet = SEX ~ STUD)
+  # Custom label still takes priority
+  p3 <- pmx_plot_iwres_ipred(
+    crt,
+    strat.color = "AGE0",
+    strat.facet = SEX ~ STUD,
+    labels=list(title="CUSTOM_A vs CUSTOM_B by CUSTOM_OVERRIDE")
+  )
 
   expect_identical(p1$labels$title, "IWRES vs IPRED by STUD")
   expect_identical(p2$labels$title, "IWRES vs IPRED by SEX and STUD")
+  expect_identical(p3[["labels"]][["title"]], "CUSTOM_A vs CUSTOM_B by CUSTOM_OVERRIDE")
 })


### PR DESCRIPTION
- a test is made to see if a `[["labels"]][["title"]]` argument has been passed
- if so, then existing logic to process the title to avoid naming by chunks is skipped

fixes #258
 