### PR TITLE
Noting multiple-endpoint renaming in Monolix

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-tinytex@master
+      - uses: r-lib/actions/setup-tinytex@v2
 
       - uses: r-lib/actions/setup-r@v1
         with:

--- a/README.Rmd
+++ b/README.Rmd
@@ -202,7 +202,7 @@ ctr <- theophylline()
 
 ### Models fitted with Monolix (versions 2016 and later) 
 
-####`pmx_mlx()`
+#### `pmx_mlx()`
 
 The controller initialization using the Monolix controller `pmx_mlx()`, which is a wrapper function for `pmx()` with `sys="mlx"` (See Appendix A).
 ```{r, eval = FALSE}
@@ -231,7 +231,7 @@ The user can verify the content of the Controller and how parameters are assigne
 
 ### Models fitted with NONMEM (versions 7.2 and later) 
 
-####`pmx_nm()`
+#### `pmx_nm()`
 
 The controller initialization using the NONMEM controller `pmx_nm()` is based on reading functions of the xpose package.
 It is highly recommended (but not required) to use the "sdtab, patab, cotab, catab" table naming convention followed by a run number (e.g. sdtab001,cotab001)
@@ -259,7 +259,7 @@ ctr <- pmx_nm(
 
 ### Models fitted with nlmixr
 
-####`pmx_nlmixr()`
+#### `pmx_nlmixr()`
 
 It is simple to create a ggPMX controller for a nlmixr object using `pmx_nlmixr()`.
 Using the theophylline example with a nlmixr model we have:
@@ -390,6 +390,11 @@ pmx_mlx(
   ...)            ## other pmx parameters , config, input,etc..
 ```
 Internally, a pmxEndpoint object will be created, and observations having YTYPE=x will be filtered.  
+
+### Note: dependent variable renaming for Monolix
+
+When fitting a multiple-endpoint model, Monolix is known to rename endpoint variables to y1, y2.
+For controller creation to work it may necessary to reverse this renaming in the simulation file (e.g. y1 -> LIDV).
 
 ## Controller with covariates
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ ctr <- theophylline()
 
 ### Models fitted with Monolix (versions 2016 and later)
 
-\#\#\#\#`pmx_mlx()`
+#### `pmx_mlx()`
 
 The controller initialization using the Monolix controller `pmx_mlx()`,
 which is a wrapper function for `pmx()` with `sys="mlx"` (See Appendix
@@ -285,7 +285,7 @@ assigned by printing it.
 
 ### Models fitted with NONMEM (versions 7.2 and later)
 
-\#\#\#\#`pmx_nm()`
+#### `pmx_nm()`
 
 The controller initialization using the NONMEM controller `pmx_nm()` is
 based on reading functions of the xpose package. It is highly
@@ -319,7 +319,7 @@ ctr <- pmx_nm(
 
 ### Models fitted with nlmixr
 
-\#\#\#\#`pmx_nlmixr()`
+#### `pmx_nlmixr()`
 
 It is simple to create a ggPMX controller for a nlmixr object using
 `pmx_nlmixr()`. Using the theophylline example with a nlmixr model we
@@ -490,6 +490,13 @@ pmx_mlx(
 
 Internally, a pmxEndpoint object will be created, and observations
 having YTYPE=x will be filtered.
+
+### Note: dependent variable renaming for Monolix
+
+When fitting a multiple-endpoint model, Monolix is known to rename
+endpoint variables to y1, y2. For controller creation to work it may
+necessary to reverse this renaming in the simulation file (e.g. y1 -\>
+LIDV).
 
 ## Controller with covariates
 


### PR DESCRIPTION
Fixes #264 

(some formatting errors in headings in README were also fixed)