### PR TITLE
Adding missing files and dirs to use custom templates (with test)

### DIFF
--- a/R/pmx-report.R
+++ b/R/pmx-report.R
@@ -162,18 +162,50 @@ pmx_draft <- function(ctr, name, template, edit) {
   }
 
   if (file.exists(template)) {
-    template_path <- system.file(
-      "rmarkdown", "templates",
-      ifelse(ctr$config$hasNpd,"npd", "standing"),
-      package = "ggPMX"
-    )
-    temp_dir <- tempdir()
-    invisible(file.copy(template_path, temp_dir, recursive = TRUE,
-                        copy.mode=FALSE))
-    dest_temp <- file.path(temp_dir, "standing", "skeleton", "skeleton.Rmd")
-    invisible(file.copy(template, dest_temp, overwrite = TRUE,
-                        copy.mode=FALSE))
+    ggPMX_dir <- system.file(package = "ggPMX")
+
+    standing_file <- system.file(
+      "rmarkdown",
+      "templates",
+      ifelse(
+        ctr$config$hasNpd &
+          dir.exists(file.path(ggPMX_dir, "rmarkdown", "templates", "npd")),
+        "npd",
+        "standing"
+      ),
+      package="ggPMX")
+
+    # Defining template and skeleton temporary subdirs, creating if missing
+    # tempdir includes random subdir, so it is new for each run
+    temp_dir <- file.path(tempdir(), paste0(sample(letters, 9), collapse=""))
+
     template_dir <- file.path(temp_dir, "standing")
+    if (!dir.exists(template_dir)) {
+      invisible(dir.create(template_dir, recursive=TRUE))
+    }
+
+    skeleton_dir <- file.path(template_dir, "skeleton")
+    if (!dir.exists(skeleton_dir)) {
+      invisible(dir.create(skeleton_dir, recursive=TRUE))
+    }
+
+    # Copying template and skeleton files to subdirectories
+    invisible({
+      file.copy(
+        from=file.path(standing_file, "template.yaml"),
+        to=template_dir,
+        overwrite=TRUE,
+        recursive=TRUE
+      )
+      file.copy(
+        from=file.path(standing_file, "skeleton", "skeleton.Rmd"),
+        to=skeleton_dir,
+        overwrite=TRUE,
+        recursive=TRUE
+      )
+    })
+
+
     res <- draft(
       template_file,
       template = template_dir,

--- a/tests/testthat/test-pmx-report.R
+++ b/tests/testthat/test-pmx-report.R
@@ -33,6 +33,22 @@ test_that("Report generation can be repeated without error", {
   )
 })
 
+test_that("Can generate report using a custom template", {
+  skip_on_cran()
+  custom_template_file <- system.file(
+    "inst", "examples", "templates", "custom_report.Rmd",
+    package="ggPMX"
+  )
+
+  expect_null(
+    pmx_report(
+      contr=ctr,
+      name="NN",
+      save_dir=tmp_dir,
+      template=custom_template_file
+    )
+  )
+})
 
 test_that("Illegal arguments to pmx_report cause an error", {
   skip_on_cran()


### PR DESCRIPTION
fixes #256 

- the error was caused by necessary template and skeleton files not being available in new subdirectory where custom template is used