### PR TITLE
Adding fix to symmetrical free scales for facet plot with test

### DIFF
--- a/R/plot-residual.R
+++ b/R/plot-residual.R
@@ -140,9 +140,47 @@ plot_pmx.residual <- function(x, dx, ...) {
         gp$ranges$x <- xrange
         gp$ranges$y <- xrange
       }
-      p <- p +
-        coord_cartesian(xlim = xrange, ylim = xrange) +
-        theme(aspect.ratio = 1)
+      p <- p + theme(aspect.ratio = 1)
+      fs <- facets[["scales"]]
+      if (((!is.null(fs)) && !(fs == "free")) || is.null(fs)) {
+        p <- p + coord_cartesian(xlim = xrange, ylim = xrange)
+      }
+      else {
+        # Adding functions to ensure equal x and y scales for each facet
+        FacetWrapEq <- ggproto(
+          "FacetWrapEq",
+          FacetWrap,
+          train_scales=function(self, x_scales, y_scales, layout, data, params) {
+            if (is.null(x_scales) || is.null(x_scales)) {stop("X scale and Y scale required")}
+            ggproto_parent(FacetWrap, self)$train_scales(x_scales, y_scales, layout, data, params)
+
+            for (d in data) {
+              match_id <- match(d[["PANEL"]], layout[["PANEL"]])
+
+              ggplot2:::scale_apply(
+                d,
+                intersect(y_scales[[1]][["aesthetics"]], names(d)),
+                "train",
+                layout[["SCALE_X"]][match_id],
+                x_scales
+              )
+
+              ggplot2:::scale_apply(
+                d,
+                intersect(x_scales[[1]][["aesthetics"]], names(d)),
+                "train",
+                layout[["SCALE_Y"]][match_id],
+                y_scales
+              )
+            }
+          }
+        )
+
+        facet_wrap_eq <- function(...) {
+          fw <- facet_wrap(...)
+          ggproto(NULL, FacetWrapEq, shrink=fw[["shrink"]], params=fw[["params"]])
+        }
+      }
     }
 
     if (is.null(gp$ranges) || is.null(gp$ranges$y)) {
@@ -166,7 +204,14 @@ plot_pmx.residual <- function(x, dx, ...) {
       if (is.character(strat.facet)) {
         strat.facet <- formula(paste0("~", strat.facet))
       }
-      p <- p + do.call("facet_wrap", c(strat.facet, facets))
+      fs <- facets[["scales"]]
+
+      facet_wrap_function <- ifelse(yes="facet_wrap_eq", no="facet_wrap",
+        {aess$y == "DV" && !(gp$scale_x_log10 || gp$scale_y_log10)} &&
+          {((!is.null(fs)) && (fs == "free"))}
+      )
+
+      p <- p + do.call(facet_wrap_function, c(strat.facet, facets))
     }
 
 

--- a/tests/testthat/test-pmx-plots-scatter.R
+++ b/tests/testthat/test-pmx-plots-scatter.R
@@ -17,6 +17,38 @@ test_that("pmx_plot_dv_pred: params: not controller result: error",
             ctr <- theophylline() %>% get_data("eta")
             expect_error(pmx_plot_dv_pred(ctr = ctr))
           })
+
+test_that("pmx_plot_dv_pred: scales='free' argument flows correctly", {
+  p <- pmx_plot_dv_pred(
+    theophylline(),
+    strat.facet = ~SEX,
+    facets=list(scales="free"),
+    labels=list(title="")
+  ) %>%
+  ggplot_build
+
+  # x and y ranges are equal per facet:
+  expect_equal(
+    p[["layout"]][["panel_scales_x"]][[1]][["range"]][["range"]],
+    p[["layout"]][["panel_scales_y"]][[1]][["range"]][["range"]]
+  )
+
+  expect_equal(
+    p[["layout"]][["panel_scales_x"]][[2]][["range"]][["range"]],
+    p[["layout"]][["panel_scales_y"]][[2]][["range"]][["range"]]
+  )
+
+  # should be a narrower max y range for facet 1:
+  expect_lt(
+    p[["layout"]][["panel_scales_y"]][[1]][["range"]][["range"]][[2]],
+    p[["layout"]][["panel_scales_y"]][[2]][["range"]][["range"]][[2]]
+  )
+
+  # check that "free" scales have been passed for both axes:
+  expect_true(p[["layout"]][["facet_params"]][["free"]][["x"]])
+  expect_true(p[["layout"]][["facet_params"]][["free"]][["y"]])
+})
+
 #------------------- pmx_plot_dv_pred end -------------------------------------
 
 #------------------- pmx_plot_iwres_time start --------------------------------


### PR DESCRIPTION
Fixes #259

- needed significant code additions since working directly on the scales on a per-facet basis is not supported out of the box by `ggplot2`