### PR TITLE
Increasing font size of correlation label and making them red color

### DIFF
--- a/inst/init/standing.ppmx
+++ b/inst/init/standing.ppmx
@@ -430,8 +430,8 @@ ETA_CONTS:
     shape: 21
     color: black
   correl:
-    colour: black
-    size: 5
+    colour: red
+    size: 4
   is.smooth: yes
   smooth:
     se: no


### PR DESCRIPTION
fixes #198 

- reduces size to same as axes labels
- color now red