### PR TITLE
Remove path prefix from sim-blq variable name

### DIFF
--- a/R/pmx-reader.R
+++ b/R/pmx-reader.R
@@ -367,7 +367,7 @@ read_mlx18_res <- function(path, x, ...) {
     xnames <- names(x[["names"]])
     yname <- substring(file_path, regexpr("s/", file_path) + 2)
     yname <- sub("_obsVsPred.txt", "", yname)
-    yname <- sub("^.*/", "", yname)
+    yname <- basename(yname)
     names(x[["names"]])[which(xnames == "y_simBlq_mode")] <- paste0(yname,"_simBlq_mode")
 
     #handling of mlx18 input, there is no y_simBlq_mean or y_simBlq_mode for Monolix version 2018

--- a/R/pmx-reader.R
+++ b/R/pmx-reader.R
@@ -367,6 +367,7 @@ read_mlx18_res <- function(path, x, ...) {
     xnames <- names(x[["names"]])
     yname <- substring(file_path, regexpr("s/", file_path) + 2)
     yname <- sub("_obsVsPred.txt", "", yname)
+    yname <- sub("^.*/", "", yname)
     names(x[["names"]])[which(xnames == "y_simBlq_mode")] <- paste0(yname,"_simBlq_mode")
 
     #handling of mlx18 input, there is no y_simBlq_mean or y_simBlq_mode for Monolix version 2018


### PR DESCRIPTION
fixes #255

- the root problem is that there is sometimes a leading path before the name of the y variable for `sim_blq` and this has to be removed so the correct column can be matched